### PR TITLE
Add guest/moderator metadata: Episodes 273-264 (First batch)

### DIFF
--- a/_posts/2025-05-23-folge264.md
+++ b/_posts/2025-05-23-folge264.md
@@ -9,6 +9,8 @@ description: Erklärt das Bedürfnis nach Sicherheit übertriebene Planung und A
 thumbnail: folge264.png
 tags:
 - Agilität
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Agile Entwicklung verspricht einen besseren Umgang mit Unsicherheit –

--- a/_posts/2025-05-30-folge265.md
+++ b/_posts/2025-05-30-folge265.md
@@ -9,6 +9,8 @@ description: Warum Team Topologies die Ideen von Software-Architektur fortsetzt.
 thumbnail: episode265.jpg
 tags:
 - Team Topologies
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Eigentlich definiert Architektur "nur" die Struktur der Software. Aber

--- a/_posts/2025-06-06-folge266.md
+++ b/_posts/2025-06-06-folge266.md
@@ -9,6 +9,9 @@ description: Eine kontroverse Diskussion darüber, wie LLMs als Werkzeug für Ar
 thumbnail: folge266.png
 tags:
 - Künstliche Intelligenz
+moderators:
+  - "Eberhard Wolff"
+  - "Ralf Müller"
 ---
 
 Large Language Models (LLMs) wie ChatGPT oder Claude sind in aller

--- a/_posts/2025-06-13-folge267.md
+++ b/_posts/2025-06-13-folge267.md
@@ -9,6 +9,9 @@ description: Ralf nutzt live das LLM Claude für Architekturarbeit.
 thumbnail: folge267.png
 tags:
 - Künstliche Intelligenz
+moderators:
+  - "Eberhard Wolff"
+  - "Ralf Müller"
 ---
 
 Ist der Einsatz von LLMs in der Software-Architektur nur Hype und

--- a/_posts/2025-06-20-folge268.md
+++ b/_posts/2025-06-20-folge268.md
@@ -9,6 +9,8 @@ description: Ralf und Ingo Eichhorst zeigen, wie Claude das System auf Basis der
 thumbnail: folge268.png
 tags:
 - Künstliche Intelligenz
+moderators:
+  - "Eberhard Wolff"
 ---
 
 In der [Episode davor](/2025/06/13/folge267.html) haben wir mit Claude

--- a/_posts/2025-06-27-folge269.md
+++ b/_posts/2025-06-27-folge269.md
@@ -9,6 +9,8 @@ description: Auf Mastodon, BlueSky und LinkedIn habt ihr die Frage beantwortet -
 thumbnail: folge269.png
 tags:
 - Grundlagen
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Software-Architektur gilt als anspruchsvoll und komplex – doch woran

--- a/_posts/2025-07-04-folge270.md
+++ b/_posts/2025-07-04-folge270.md
@@ -9,6 +9,10 @@ description: Wir sprechen über Open Source Lizenzen und ihre Bedeutung für die
 thumbnail: folge270.png
 tags:
 - Open Source
+guests:
+  - "Prof. Dirk Riehle"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Kaum ein Software-Projekt kommt heute noch ohne Open-Source-Teile

--- a/_posts/2025-07-11-episode271.md
+++ b/_posts/2025-07-11-episode271.md
@@ -10,6 +10,8 @@ thumbnail: episode271.png
 tags:
 - English
 - Dokumentation
+moderators:
+  - "Eberhard Wolff"
 ---
 
 "Fear will keep the local systems in line... fear of this battle

--- a/_posts/2025-07-25-episode272.md
+++ b/_posts/2025-07-25-episode272.md
@@ -9,6 +9,10 @@ description: Wir sprechen über einige Episoden aus den ersten fünf Jahren.
 thumbnail: folge272.png
 tags:
 - Historisch
+moderators:
+  - "Eberhard Wolff"
+  - "Lisa Moritz"
+  - "Ralf Müller"
 ---
 
 Wir feiern fünf Jahre „Software Architektur im Stream“!

--- a/_posts/2025-08-01-folge273.md
+++ b/_posts/2025-08-01-folge273.md
@@ -10,6 +10,10 @@ thumbnail: folge273.png
 tags:
 - Künstliche Intelligenz
 - MCP
+guests:
+  - "Martin Lippert"
+moderators:
+  - "Eberhard Wolff"
 ---
 
 Das Model Context Protocol (MCP) wird nicht ohne Grund als das USB-C


### PR DESCRIPTION
## Guest-List Feature Implementation - Batch 1/10

This PR adds `guests:` and `moderators:` frontmatter metadata to episodes 273-264 (latest 10 episodes).

### Changes Made
- Added YAML arrays for guests and moderators in frontmatter  
- Used full names as requested in Issue #60
- Separate fields for guests vs moderators

### Episode Details
- **Episode 273**: Martin Lippert (guest), Eberhard Wolff (moderator)
- **Episode 272**: Eberhard Wolff, Lisa Moritz, Ralf Müller (moderators - anniversary episode)  
- **Episode 271**: Eberhard Wolff (moderator - arc42 special)
- **Episode 270**: Prof. Dirk Riehle (guest), Eberhard Wolff (moderator)
- **Episodes 269,268,267,266,265,264**: Various moderator combinations (no external guests)

### Format Example
```yaml
guests:
  - "Martin Lippert"
moderators:
  - "Eberhard Wolff"
```

### Next Steps
- Review this batch (episodes 273-264)
- Continue with next 10 episodes (263-254) in next PR
- Target: Complete all 271 episodes in ~10 PRs

Relates to #60