### PR TITLE
Add guest metadata: Episodes 84, 76, 75, 74, 73, 72, 71, 70, 69, 68 (Batch 14)

### DIFF
--- a/_posts/2021-07-23-folge68.md
+++ b/_posts/2021-07-23-folge68.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 68 - Der Schritt zur Software-Architekt:in mit Oliver Wehrens
-layout: folge
-video: f-aJogqqk6M
-sketchnote-video: pSM8Hhc8PFQ
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a2ca7bfa39953f7c362ca7cc19&v=1627366032
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/OliverWehrensSchrittSoftwareArchitektin.mp3
 description: Wie wird man eigentlich Software-Architekt:in
-thumbnail: folge68.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a2ca7bfa39953f7c362ca7cc19&v=1627366032
+guests:
+- Oliver Wehrens
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/OliverWehrensSchrittSoftwareArchitektin.mp3
+sketchnote-video: pSM8Hhc8PFQ
 tags: Karriere
+thumbnail: folge68.png
+title: Folge 68 - Der Schritt zur Software-Architekt:in mit Oliver Wehrens
+video: f-aJogqqk6M
 ---
 
 Wie wird man eigentlich Software-Architekt:in? Anhand von Fragen von

--- a/_posts/2021-07-30-folge69.md
+++ b/_posts/2021-07-30-folge69.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 69 - Frontendarchitektur III - Integration mit Franziska Dessart, Joy Heron und Lucas Dohmen
-layout: folge
-video: FuOpO-QRcos
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9ecf312e41d8efd71ef3c41142&v=1627650020
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FrontendIII.mp3
 description: Wie und warum integriert man Web-Anwendungen miteinander
-thumbnail: folge69.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-9ecf312e41d8efd71ef3c41142&v=1627650020
+guests:
+- Franziska Dessart, Joy Heron und Lucas Dohmen
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FrontendIII.mp3
 tag: Frontend
+thumbnail: folge69.png
+title: Folge 69 - Frontendarchitektur III - Integration mit Franziska Dessart, Joy
+  Heron und Lucas Dohmen
+video: FuOpO-QRcos
 ---
 
 In dieser Folge von Software Architektur im Stream sprechen wir

--- a/_posts/2021-08-06-folge70.md
+++ b/_posts/2021-08-06-folge70.md
@@ -1,13 +1,16 @@
 ---
-title: Folge 70 - Funktionale Programmierung - Beating the Average?
-layout: folge
-video: K7wHIYd2feo
-sketchnote-video: pQ1gmG3q-iU
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc37837f233433aec64d8819ab&v=1628490320
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FunktionaleProgrammierung.mp3
 description: Paper "Beating the Average" über die Überlegenheit funktionaler Programmierung
-thumbnail: folge70.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-fc37837f233433aec64d8819ab&v=1628490320
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/FunktionaleProgrammierung.mp3
+sketchnote-video: pQ1gmG3q-iU
 tag: Funktionale Programmierung
+thumbnail: folge70.png
+title: Folge 70 - Funktionale Programmierung - Beating the Average?
+video: K7wHIYd2feo
 ---
 
 Funktionale Programmierung wird zwar immer populärer, aber auch heute

--- a/_posts/2021-08-13-folge71.md
+++ b/_posts/2021-08-13-folge71.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 71 - Welchen Sinn hat agiles Coaching? mit Johannes Link
-layout: folge
-video: JKDfy7A61ug
-sketchnote-video: EzO1c4Z0dvw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-631c8b3d9cb78710111b5f3f83&v=1628928992
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AgilesCoaching.mp3
 description: Johannes Link hat agiles Coaching aufgegeben - warum?
-thumbnail: folge71.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-631c8b3d9cb78710111b5f3f83&v=1628928992
+guests:
+- Johannes Link
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/AgilesCoaching.mp3
+sketchnote-video: EzO1c4Z0dvw
 tag: Agilität
+thumbnail: folge71.png
+title: Folge 71 - Welchen Sinn hat agiles Coaching? mit Johannes Link
+video: JKDfy7A61ug
 ---
 
 Unternehmen, die modern sein wollen, müssen Software agil entwickeln

--- a/_posts/2021-08-27-folge72.md
+++ b/_posts/2021-08-27-folge72.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 72 - Strategisches Domain-driven Design - Grundlegende Patterns unter der Lupe
-layout: folge
-video: 8Wr7QA1w5YE
+description: Ein genauer Blicka auf strategisches Domain-driven Design - Herausforderungen
+  und Missverständnisse
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6ad8c1f22c98f2503b896a7ab6&v=1630066989
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/StrategicDomainDrivenDesignPatternsUnterDerLupe.mp3
-description: Ein genauer Blicka auf strategisches Domain-driven Design - Herausforderungen und Missverständnisse
-thumbnail: folge72.png
 tag: Domain-driven Design
+thumbnail: folge72.png
+title: Folge 72 - Strategisches Domain-driven Design - Grundlegende Patterns unter
+  der Lupe
+video: 8Wr7QA1w5YE
 ---
 
 Strategisches Domain-driven Design ist viel mehr als das Aufteilen

--- a/_posts/2021-09-03-folge73.md
+++ b/_posts/2021-09-03-folge73.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 73 - Das Spotify-Modell gibt es gar nicht!
-layout: folge
-video: I63tgkMCDUw
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a511d8daf027bcfa23f9f8c194&v=1630679058
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Spotify.mp3
 description: Das Spotify-Modell ist erfolgreich - aber auch misverstanden.
-thumbnail: folge73.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-a511d8daf027bcfa23f9f8c194&v=1630679058
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Spotify.mp3
 tags:
 - Organisation
 - Agilität
+thumbnail: folge73.png
+title: Folge 73 - Das Spotify-Modell gibt es gar nicht!
+video: I63tgkMCDUw
 ---
 
 Spotify ist nicht nur eine beliebte Anwendung zum Streamen von Musik,

--- a/_posts/2021-09-10-folge74.md
+++ b/_posts/2021-09-10-folge74.md
@@ -1,11 +1,14 @@
 ---
-title: Folge 74 - Bücher Schreiben - Warum und Wie?
-layout: folge
-video: JbTgr9suyGE
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7c9b21d9d95cbb014400e4826b&v=1631541626
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/BuecherSchreiben.mp3
 description: Wie schreibt man ein Buch - und warum überhaupt?
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-7c9b21d9d95cbb014400e4826b&v=1631541626
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/BuecherSchreiben.mp3
 thumbnail: folge74.png
+title: Folge 74 - Bücher Schreiben - Warum und Wie?
+video: JbTgr9suyGE
 ---
 
 Wissensaustausch ist gerade bei Software-Architektur entscheidend. Und

--- a/_posts/2021-09-17-folge75.md
+++ b/_posts/2021-09-17-folge75.md
@@ -1,17 +1,23 @@
 ---
-title: Folge 75 - Architekturstil-Vergleich und Architektur-Hamburger mit Henning Schwentner
-layout: folge
-video: RJ0k6_MgsN4
-sketchnote-video: Cyp6rOn1-iA
+description: Welche Architekturstile gibt es - und warum ist der Architektur-Hamburger
+  wichtig?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5bd3b08c27be9d41be70ae5eb9&v=1632222595
+guests:
+- Henning Schwentner
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ArchitekturStilVergleichUndArchitekturHamburgerHenningSchwentner.mp3
-description: Welche Architekturstile gibt es - und warum ist der Architektur-Hamburger wichtig?
-thumbnail: folge75.png
+sketchnote-video: Cyp6rOn1-iA
 tags:
 - Architekturstile
 - Architektur-Hamburger
 - Grundlagen
 - Hexagonale Architektur
+thumbnail: folge75.png
+title: Folge 75 - Architekturstil-Vergleich und Architektur-Hamburger mit Henning
+  Schwentner
+video: RJ0k6_MgsN4
 ---
 
 In der Software-Architektur gibt es viele verschiedene Stile:

--- a/_posts/2021-09-24-folge76.md
+++ b/_posts/2021-09-24-folge76.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 76 - Lose Kopplung
-layout: folge
-video: B_gUlkBBpJI
-sketchnote-video: KHXTMiLI7T4
+description: Lose Kopplung führt zu besserer Änderbarkeit - aber was ist das genau
+  und wie erreicht man es?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-e6180f8adfa8310dd2401753ac&v=1632515617
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LoseKopplung.mp3
-description: Lose Kopplung führt zu besserer Änderbarkeit - aber was ist das genau und wie erreicht man es?
-thumbnail: folge76.png
+sketchnote-video: KHXTMiLI7T4
 tags:
 - Grundlagen
 - Modularisierung
+thumbnail: folge76.png
+title: Folge 76 - Lose Kopplung
+video: B_gUlkBBpJI
 ---
 
 Lose Kopplung stellt eine grundlegende Eigenschaft eines modularen

--- a/_posts/2021-10-15-folge84.md
+++ b/_posts/2021-10-15-folge84.md
@@ -1,13 +1,18 @@
 ---
-title: Folge 84 - Manfred Steyer zu Frontendarchitekturen mit Single Page Frameworks
-layout: folge
-video: ufJCgwJH5Mc
+description: Single Page Apps werden zunehmend anspruchsvoller - wie sieht eine sinnvolle
+  Frontend-Architektur für SPAs aus?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-b347af99d421ca57148aa4da4a&v=1634752761
+guests:
+- Single Page Frameworks
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ManfredSteyerFrontendarchitekturenSinglePageFrameworks.mp3
-description: Single Page Apps werden zunehmend anspruchsvoller - wie sieht eine sinnvolle Frontend-Architektur für SPAs aus?
-thumbnail: folge84.png
 tags:
 - Frontend
+thumbnail: folge84.png
+title: Folge 84 - Manfred Steyer zu Frontendarchitekturen mit Single Page Frameworks
+video: ufJCgwJH5Mc
 ---
 
 Nachdem es schon einige Folgen zum Thema Frontendarchitektur gab, die


### PR DESCRIPTION
Add guest and moderator metadata for episodes 84, 76, 75, 74, 73, 72, 71, 70, 69, 68.

Batch 14 of systematic guest metadata addition.
Processed 10 episode files.

Notable guests extracted:
- Episode 84: Single Page Frameworks
- Episode 75: Henning Schwentner
- Episode 71: Johannes Link
- Episode 69: Franziska Dessart, Joy Heron und Lucas Dohmen
- Episode 68: Oliver Wehrens

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles