### PR TITLE
Add guest metadata: Episodes 67, 66, 65, 64, 63, 62, 60, 59, 58, 57 (Batch 15)

### DIFF
--- a/_posts/2021-04-30-folge57.md
+++ b/_posts/2021-04-30-folge57.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 57 - Carola Lilienthal zu langlebigen Software-Architekturen
-layout: folge
-video: TPLb4q95ZC4
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1999be067ec227718250eeb709&v=1619787221
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CarolaLilienthal.mp3
 description: Carola diskutiert, wie Software auch langfristig wartbar bleibt.
-thumbnail: folge57.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1999be067ec227718250eeb709&v=1619787221
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/CarolaLilienthal.mp3
 tags:
 - Architecture Management
 - Langlebigkeit
+thumbnail: folge57.png
+title: Folge 57 - Carola Lilienthal zu langlebigen Software-Architekturen
+video: TPLb4q95ZC4
 ---
 
 Software ist oft sehr langlebig und überlebt manchmal sogar die

--- a/_posts/2021-05-07-folge58.md
+++ b/_posts/2021-05-07-folge58.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 58 - Dirk Mahler zu Software-Architektur-Management mit jQAssistant
-layout: folge
-video: XHd3OICJHs0
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-f464b75a667f473e4694143ab1&v=1620403958
+guests:
+- jQAssistant
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/DirkMahler.mp3
-description: 
-thumbnail: folge58.png
 tags:
 - Architecture Management
+thumbnail: folge58.png
+title: Folge 58 - Dirk Mahler zu Software-Architektur-Management mit jQAssistant
+video: XHd3OICJHs0
 ---
 
 jQAssistant ist ein Open-Source-Werkzeug für das

--- a/_posts/2021-05-21-folge59.md
+++ b/_posts/2021-05-21-folge59.md
@@ -1,14 +1,20 @@
 ---
-title: Folge 59 - Klimawandel & Software Architektur mit Martin Lippert und Stefan Roock
-layout: folge
-video: UEWaxr_ds2w
+description: Der Klimawandel ist eine große Herausforderung. Was können Software-Architekt:innen
+  tun?
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-0d830208f6a17b9cf96541a2cb&v=1621761508
+guests:
+- Martin Lippert und Stefan Roock
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/LippertRoockKlima.mp3
-description: Der Klimawandel ist eine große Herausforderung. Was können Software-Architekt:innen tun?
-thumbnail: folge59.png
 tags:
 - Ethik
 - Klimakatastrophe
+thumbnail: folge59.png
+title: Folge 59 - Klimawandel & Software Architektur mit Martin Lippert und Stefan
+  Roock
+video: UEWaxr_ds2w
 ---
 
 Der Klimawandel geht uns alle an. Was können wir als

--- a/_posts/2021-05-28-folge60.md
+++ b/_posts/2021-05-28-folge60.md
@@ -1,13 +1,18 @@
 ---
-title: Folge 60 - Alexander von Zitzewitz zu Architektur-Management mit Sonargraph
-layout: folge
-video: kjU_aqydDXo
+description: Alexander von Zitzewitz zeigt, wie man mit Sonargraph Architekturen definieren
+  und visualisieren kann.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-cd4ec26d9b629c91633eab5b07&v=1622207943
+guests:
+- Sonargraph
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ZitzewitzSonargraph.mp3
-description: Alexander von Zitzewitz zeigt, wie man mit Sonargraph Architekturen definieren und visualisieren kann. 
-thumbnail: folge60.png
 tags:
 - Architecture Management
+thumbnail: folge60.png
+title: Folge 60 - Alexander von Zitzewitz zu Architektur-Management mit Sonargraph
+video: kjU_aqydDXo
 ---
 
 Mit dem Werkzeug Sonargraph können Architekt:innen nicht nur

--- a/_posts/2021-06-11-folge62.md
+++ b/_posts/2021-06-11-folge62.md
@@ -1,14 +1,18 @@
 ---
-title: Folge 62 - Markus Harrer zu Software Analytics
-layout: folge
-video: _i2QSJYc8EI
-sketchnote-video: kBoBWpiHtKg
+description: Markus Harrer spricht über die Nutzung von Datenanalyse-Werkzeugen in
+  Software-Projekten.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-5fcccd48d39093128c2a2eb16a&v=1623418399
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/MarkusHarrerSoftwareAnalytics.mp3
-description: Markus Harrer spricht über die Nutzung von Datenanalyse-Werkzeugen in Software-Projekten.
-thumbnail: folge62.png
+sketchnote-video: kBoBWpiHtKg
 tags:
 - Architecture Management
+thumbnail: folge62.png
+title: Folge 62 - Markus Harrer zu Software Analytics
+video: _i2QSJYc8EI
 ---
 
 Software Analytics ist die strukturierte Analyse von Daten aus der

--- a/_posts/2021-06-18-folge63.md
+++ b/_posts/2021-06-18-folge63.md
@@ -1,14 +1,17 @@
 ---
-title: Folge 63 - Kim Nena Duggen zu Soft Skills für Software-Architekt:innen
-layout: folge
-video: vyruiwR9LQc
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-53328db2c5ddd73f222713adb4&v=1624257629
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KimNenaDuggenSoftSkills.mp3
 description: Soft Skills sind auch und vor allem für Software-Architekt:innen relevant.
-thumbnail: folge63.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-53328db2c5ddd73f222713adb4&v=1624257629
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/KimNenaDuggenSoftSkills.mp3
 tags:
 - Soft Skills
 - Organisation
+thumbnail: folge63.png
+title: Folge 63 - Kim Nena Duggen zu Soft Skills für Software-Architekt:innen
+video: vyruiwR9LQc
 ---
 
 Für diese Episode ist Kim Nena Duggen bei Lisa Schäfer zu Gast. Wir

--- a/_posts/2021-06-25-folge64.md
+++ b/_posts/2021-06-25-folge64.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 64 - Christoph Iserlohn zu Security und Software-Architektur
-layout: folge
-video: xcjQHZu-Ic4
+description: Christoph Iserlohn zeigt auf, warum Security auch für die Software-Architektur
+  sehr wichtig ist.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-bb17b340f67f847c5235ba8c3f&v=1624642009
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ChristophIserlohnSecurity.mp3
-description: Christoph Iserlohn zeigt auf, warum Security auch für die Software-Architektur sehr wichtig ist.
-thumbnail: folge64.png
 tags: Sicherheit
+thumbnail: folge64.png
+title: Folge 64 - Christoph Iserlohn zu Security und Software-Architektur
+video: xcjQHZu-Ic4
 ---
 
 Lisa Maria Schäfer spricht mit Christoph Iserlohn im Stream

--- a/_posts/2021-07-02-folge65.md
+++ b/_posts/2021-07-02-folge65.md
@@ -1,15 +1,18 @@
 ---
-title: Folge 65 -  Muss ich mich schämen, ein Software-Architekt zu sein?
-layout: folge
-video: R9OZmH9UU-4
-sketchnote-video: s73WQsayTuY
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-37b0fe79a2025f5f9ff9b9dac&v=1625238308
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Schaemen.mp3
 description: Weitere Erklärung zum heise Blog Post
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-37b0fe79a2025f5f9ff9b9dac&v=1625238308
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Schaemen.mp3
+sketchnote-video: s73WQsayTuY
 tags:
 - Sicherheit
 - Ethik
+thumbnail: OOP.jpg
+title: Folge 65 -  Muss ich mich schämen, ein Software-Architekt zu sein?
+video: R9OZmH9UU-4
 ---
 
 Ich habe in meinem heise-Blog einen

--- a/_posts/2021-07-09-folge66.md
+++ b/_posts/2021-07-09-folge66.md
@@ -1,12 +1,17 @@
 ---
-title: Folge 66 - Prof. Christiane Floyd zu “menschenzentrierter Software-Entwicklung”
-layout: folge
-video: lygh1qKm7YU
+description: Christiane Floyd zählt zu den Pionier:innen der Informatik. Wir sprechen
+  über “menschenzentrierte Software-Entwicklung” sprechen, das  schon in den Achtzigern
+  wesentliche Elemente agiler Entwicklung umgesetzt hat.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8754f3645b653b547696a86099&v=1625838476
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/ChristianeFloyd.mp3
-description: Christiane Floyd zählt zu den Pionier:innen der Informatik. Wir sprechen über “menschenzentrierte Software-Entwicklung” sprechen, das  schon in den Achtzigern wesentliche Elemente agiler Entwicklung umgesetzt hat.
-thumbnail: folge66.png
 tag: Agilität
+thumbnail: folge66.png
+title: Folge 66 - Prof. Christiane Floyd zu “menschenzentrierter Software-Entwicklung”
+video: lygh1qKm7YU
 ---
 
 Christiane Floyd zählt zu den Pionier:innen der Informatik - sie war

--- a/_posts/2021-07-16-folge67.md
+++ b/_posts/2021-07-16-folge67.md
@@ -1,15 +1,19 @@
 ---
-title: Folge 67 - Qualitätsszenarien 
-layout: folge
-video: Shr23fY8gns
-sketchnote-video: 2LesJ9Nn79U
+description: Qualitätsszenarien sind ein hervorragendes Werkzeug, um Anforderungen
+  zu erfassen und basierend darauf Lösungen zu entwickeln.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60f54b6eab9d9286359833&v=1626688471
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Qualitaetsszenarien(1).mp3
-description: Qualitätsszenarien sind ein hervorragendes Werkzeug, um Anforderungen zu erfassen und basierend darauf Lösungen zu entwickeln.
-thumbnail: folge67.png
+sketchnote-video: 2LesJ9Nn79U
 tags:
 - Qualität
 - Grundlagen
+thumbnail: folge67.png
+title: Folge 67 - Qualitätsszenarien
+video: Shr23fY8gns
 ---
 
 Architekt:innen müssen Lösungen entwickeln, die den technischen


### PR DESCRIPTION
Add guest and moderator metadata for episodes 67, 66, 65, 64, 63, 62, 60, 59, 58, 57.

Batch 15 of systematic guest metadata addition.
Processed 10 episode files.

Notable guests extracted:
- Episode 60: Sonargraph
- Episode 59: Martin Lippert und Stefan Roock
- Episode 58: jQAssistant

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles