### PR TITLE
Add guest metadata: Episodes 56, 55, 54, 53, 52, 51, 50, 49, 48, 47 (Batch 16)

### DIFF
--- a/_posts/2021-02-11-folge47.md
+++ b/_posts/2021-02-11-folge47.md
@@ -1,15 +1,18 @@
 ---
-title: Episode 47 - Grady Booch - AI Architecture and Systems - Live from OOP
-layout: folge
-video: lfcLOKzolpQ
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603287fb620f6739759128&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Booch.mp3
 description: Architecting AI systems is very different.
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603287fb620f6739759128&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Booch.mp3
 tags:
 - Live von der OOP
 - English
 - Künstliche Intelligenz
+thumbnail: OOP.jpg
+title: Episode 47 - Grady Booch - AI Architecture and Systems - Live from OOP
+video: lfcLOKzolpQ
 ---
 
 Grady Booch is one of the pioneers of software architecture. Lately,

--- a/_posts/2021-02-11-folge48.md
+++ b/_posts/2021-02-11-folge48.md
@@ -1,15 +1,18 @@
 ---
-title: Episode 48 - Aino Vonge Corry - Retrospectives - Live from OOP with Lisa Schäfer
-layout: folge
-video: NmgwM7x5Yuo
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603288b601a8e849389077&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Corry.mp3
 description: How to do retrospectives successfully.
-thumbnail: OOP.jpg
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603288b601a8e849389077&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Corry.mp3
 tags:
 - Live von der OOP
 - English
 - Retrospectives
+thumbnail: OOP.jpg
+title: Episode 48 - Aino Vonge Corry - Retrospectives - Live from OOP with Lisa Schäfer
+video: NmgwM7x5Yuo
 ---
 
 We want to talk about retrospectives in detail - how to make them

--- a/_posts/2021-02-11-folge49.md
+++ b/_posts/2021-02-11-folge49.md
@@ -1,17 +1,21 @@
 ---
-title: Episode 49 - Linda Rising - Fearless Change and the Unconscious Mind - Live from OOP
-layout: folge
-video: WD6WCeBQRgU
+description: null
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60328bcaa9319669017506&v=1614151242
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Rising.mp3
-description: 
-thumbnail: OOP.jpg
 tags:
 - Live von der OOP
 - English
 - Agilität
 - Fearless Change
 - Fearless Journey
+thumbnail: OOP.jpg
+title: Episode 49 - Linda Rising - Fearless Change and the Unconscious Mind - Live
+  from OOP
+video: WD6WCeBQRgU
 ---
 
 Linda Rising is well-known for Fearless Change, a practical guide to

--- a/_posts/2021-02-19-folge50.md
+++ b/_posts/2021-02-19-folge50.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 50 - Diversity mit Lars Hupel, Lena Kraaz und Aminata Sidibe
-layout: folge
-video: Jh7ive1xiLE
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60328c70a3c7d964500360&v=1614151242
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Diversity.mp3
 description: Diversity spielt auch für Software-Architektur eine Rolle.
-thumbnail: folge50.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-60328c70a3c7d964500360&v=1614151242
+guests:
+- Lars Hupel, Lena Kraaz und Aminata Sidibe
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Diversity.mp3
 tags: Diversity
+thumbnail: folge50.png
+title: Folge 50 - Diversity mit Lars Hupel, Lena Kraaz und Aminata Sidibe
+video: Jh7ive1xiLE
 ---
 
 Gerade in der Software-Entwicklung sind viele Gruppen

--- a/_posts/2021-02-26-folge51.md
+++ b/_posts/2021-02-26-folge51.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 51 - Agilität 
-layout: folge
-video: o0oPE4Tbqxw
+description: Agilität scheint als Methode zu dominieren - aber es gibt leider dennoch
+  sehr viele Herausforderungen.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-603b8bbd0c4c6848521468&v=1614516076
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/Agilitaet.mp3
-description: Agilität scheint als Methode zu dominieren - aber es gibt leider dennoch sehr viele Herausforderungen.
-thumbnail: folge51.png
 tags: Agilität
+thumbnail: folge51.png
+title: Folge 51 - Agilität
+video: o0oPE4Tbqxw
 ---
 
 

--- a/_posts/2021-03-05-folge52.md
+++ b/_posts/2021-03-05-folge52.md
@@ -1,12 +1,16 @@
 ---
-title: Folge 52 - APIs mit Erik Wilde
-layout: folge
-video: GYtSM6jpV5o
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8428699fa623bb2befd3fa0872&v=1615019909
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/APIs.mp3
 description: APIs helfen bei der Integration in der IT und bei Wiederverwendung.
-thumbnail: folge52.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-8428699fa623bb2befd3fa0872&v=1615019909
+guests:
+- Erik Wilde
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/APIs.mp3
 tags: API
+thumbnail: folge52.png
+title: Folge 52 - APIs mit Erik Wilde
+video: GYtSM6jpV5o
 ---
 
 APIs sind ein wesentlicher Teil moderner Software-Entwicklung. Ansätze

--- a/_posts/2021-03-19-folge53.md
+++ b/_posts/2021-03-19-folge53.md
@@ -1,12 +1,15 @@
 ---
-title: Folge 53 - Q&A 
-layout: folge
-video: aaDZ_03RWrA
-embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1bd76d12ba5458d286bfe646c4&v=1616430165
-mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/QandA.mp3
 description: Antworten auf Fragen der Zuschauer:innen
-thumbnail: folge53.png
+embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-1bd76d12ba5458d286bfe646c4&v=1616430165
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
+mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/QandA.mp3
 tags: Q&A
+thumbnail: folge53.png
+title: Folge 53 - Q&A
+video: aaDZ_03RWrA
 ---
 
 In dieser Folge beantworte ich eure Fragen, die ihr entweder im Chat

--- a/_posts/2021-04-01-folge54.md
+++ b/_posts/2021-04-01-folge54.md
@@ -1,14 +1,19 @@
 ---
-title: Folge 54 - GraalVM mit Spring Native, Spring Boot und Spring Cloud
-layout: folge
-video: rjN8DSoxGCo
+description: Spring Native erleichtert es, Spring-Boot-Java-Anwendung mit der GraalVM
+  zu nativen Images zu kompilieren.
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-45c090c4e4d32b15f528428ea5&v=1617712276
+guests:
+- Spring Native, Spring Boot und Spring Cloud
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/GraalVM.mp3
-description: Spring Native erleichtert es, Spring-Boot-Java-Anwendung mit der GraalVM zu nativen Images zu kompilieren.
-thumbnail: folge54.png
 tags:
 - Microservices
 - GraalVM
+thumbnail: folge54.png
+title: Folge 54 - GraalVM mit Spring Native, Spring Boot und Spring Cloud
+video: rjN8DSoxGCo
 ---
 
 Spring Native soll die Möglichkeit bieten, Spring-Boot-Anwendungen

--- a/_posts/2021-04-09-folge55.md
+++ b/_posts/2021-04-09-folge55.md
@@ -1,13 +1,17 @@
 ---
-title: Folge 55 - Peter Gafert zu ArchUnit
-layout: folge
-video: XgVlEagYA_w
+description: Peter Gafert zu ArchUnit - einem Tool zum Testen der Architektur von
+  Java-Systemen
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-6607368d2132e02000556c5a27&v=1617973352
+guests: []
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/PeterGafert.mp3
-description: Peter Gafert zu ArchUnit - einem Tool zum Testen der Architektur von Java-Systemen
-thumbnail: folge55.png
 tags:
 - Architecture Management
+thumbnail: folge55.png
+title: Folge 55 - Peter Gafert zu ArchUnit
+video: XgVlEagYA_w
 ---
 
 Es gibt zahlreiche Werkzeuge für Software-Architektur-Management. Mit

--- a/_posts/2021-04-16-folge56.md
+++ b/_posts/2021-04-16-folge56.md
@@ -1,13 +1,19 @@
 ---
-title: Folge 56 - Remote Mob Programming mit Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
-layout: folge
-video: -02gte-IKpY
+description: Remote Mob Programming  verspricht Softwareentwicklung mit dem ultimativen
+  Teamerlebnis und dem ultimativem Teamergebnis
 embedded-mp3: https://www.podcaster.de/simpleplayer/?id=show~1evriw~software-architektur-im-stream~pod-607c90c2e8329118113654&v=1618776694
+guests:
+- Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
+layout: folge
+moderators:
+- Eberhard Wolff
 mp3: https://1evriw.podcaster.de/software-architektur-im-stream/media/RemoteMob.mp3
-description: Remote Mob Programming  verspricht Softwareentwicklung mit dem ultimativen Teamerlebnis und dem ultimativem Teamergebnis 
-thumbnail: folge56.png
 tags:
 - Mob Programming
+thumbnail: folge56.png
+title: Folge 56 - Remote Mob Programming mit Jochen Christ, Franziska Dessart, Simon
+  Harrer, Martin Huber
+video: -02gte-IKpY
 ---
 
 Mob Programming: Einer/eine tippt, die anderen denken. Das verspricht


### PR DESCRIPTION
Add guest and moderator metadata for episodes 56, 55, 54, 53, 52, 51, 50, 49, 48, 47.

Batch 16 of systematic guest metadata addition.
Processed 10 episode files.

Notable guests extracted:
- Episode 56: Jochen Christ, Franziska Dessart, Simon Harrer, Martin Huber
- Episode 54: Spring Native, Spring Boot und Spring Cloud
- Episode 52: Erik Wilde
- Episode 50: Lars Hupel, Lena Kraaz und Aminata Sidibe

Changes:
- Added 'guests' field with extracted guest names from episode titles
- Added 'moderators' field with ["Eberhard Wolff"]
- Used regex pattern matching to extract guests from "mit" patterns in titles